### PR TITLE
Nw register auth

### DIFF
--- a/apptrakz/urls.py
+++ b/apptrakz/urls.py
@@ -1,8 +1,17 @@
 from django.conf import settings
+from django.conf.urls import url
 from django.conf.urls.static import static
 from django.contrib import admin
 from django.urls import path
+# from rest_framework import routers
+
+from apptrakzapi.models import *
+from apptrakzapi.views import *
+
+# router = routers.DefaultRouter(trailing_slash=False)
 
 urlpatterns = [
+    url(r'^register$', register_user),
+    url(r'^login$', login_user),
     path('admin/', admin.site.urls),
 ] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)

--- a/apptrakzapi/views/__init__.py
+++ b/apptrakzapi/views/__init__.py
@@ -1,0 +1,1 @@
+from .register import register_user, login_user

--- a/apptrakzapi/views/register.py
+++ b/apptrakzapi/views/register.py
@@ -1,0 +1,90 @@
+"""Register user"""
+import json
+from django.http import HttpResponse, HttpResponseNotAllowed
+from django.contrib.auth import authenticate
+from django.contrib.auth.models import User
+from django.views.decorators.csrf import csrf_exempt
+from rest_framework import status
+from rest_framework.authtoken.models import Token
+
+from apptrakzapi.models import Profile
+
+
+@csrf_exempt
+def login_user(request):
+    '''Handles the authentication of a user
+    Method arguments:
+      request -- The full HTTP request object
+    '''
+
+    body = request.body.decode('utf-8')
+    req_body = json.loads(body)
+
+    # If the request is a HTTP POST, try to pull out the relevant information.
+    if request.method == 'POST':
+
+        # Use the built-in authenticate method to verify
+        name = req_body['username']
+        pass_word = req_body['password']
+        authenticated_user = authenticate(username=name, password=pass_word)
+
+        # If authentication was successful, respond with their token
+        if authenticated_user is not None:
+            token = Token.objects.get(user=authenticated_user)
+            data = json.dumps(
+                {"valid": True, "token": token.key, "id": authenticated_user.id})
+            return HttpResponse(data, content_type='application/json')
+
+        else:
+            # Bad login details were provided. So we can't log the user in.
+            data = json.dumps({"valid": False})
+            return HttpResponse(data, content_type='application/json')
+
+    return HttpResponseNotAllowed(permitted_methods=['POST'])
+
+
+@csrf_exempt
+def register_user(request):
+    '''Handles the creation of a new user for authentication
+    Method arguments:
+      request -- The full HTTP request object
+    '''
+
+    # Load the JSON string of the request body into a dict
+    req_body = json.loads(request.body.decode())
+
+    # Create a new user by invoking the `create_user` helper method
+    # on Django's built-in User model
+    new_user = User.objects.create_user(
+        username=req_body['username'],
+        email=req_body['email'],
+        password=req_body['password'],
+        first_name=req_body['first_name'],
+        last_name=req_body['last_name']
+    )
+
+    if "bio" in req_body:
+        bio = req_body["bio"]
+    else:
+        bio = None
+
+    if "profile_image" in req_body:
+        profile_image = req_body["profile_image"]
+    else:
+        profile_image = None
+
+    profile = Profile.objects.create(
+        bio=bio,
+        profile_image=profile_image,
+        user=new_user
+    )
+
+    # Commit the user to the database by saving it
+    profile.save()
+
+    # Use the REST Framework's token generator on the new user account
+    token = Token.objects.create(user=new_user)
+
+    # Return the token to the client
+    data = json.dumps({"token": token.key, "id": new_user.id})
+    return HttpResponse(data, content_type='application/json', status=status.HTTP_201_CREATED)

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+from .register import RegisterTests

--- a/tests/register.py
+++ b/tests/register.py
@@ -48,3 +48,21 @@ class RegisterTests(APITestCase):
         self.assertEqual(json_response["valid"], True)
         self.assertEqual(json_response["id"], 1)
         self.assertIn("token", json_response)
+
+    def test_login_user_failure(self):
+        """
+        Verify bad credentials are not accepted (returns "valid = false")
+        """
+
+        # Register a user
+        self.test_register_user()
+
+        url = "/login"
+        data = {
+            "username": "testuser",
+            "password": "badpassword"
+        }
+        response = self.client.post(url, data, format='json')
+        json_response = json.loads(response.content)
+
+        self.assertEqual(json_response["valid"], False)

--- a/tests/register.py
+++ b/tests/register.py
@@ -1,0 +1,50 @@
+import json
+from rest_framework import status
+from rest_framework.test import APITestCase
+from django.contrib.auth.models import User
+
+
+class RegisterTests(APITestCase):
+    def setUp(self) -> None:
+        pass
+
+    def test_register_user(self):
+        """
+        Register a user
+        """
+
+        url = "/register"
+        data = {
+            "username": "testuser",
+            "email": "testuser@test.com",
+            "password": "testpassword",
+            "first_name": "test",
+            "last_name": "user"
+        }
+        response = self.client.post(url, data, format='json')
+        json_response = json.loads(response.content)
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertIn("token", json_response)
+        self.assertIn("id", json_response)
+        self.assertEqual(json_response["id"], 1)
+
+    def test_login_user(self):
+        """
+        Login a user
+        """
+
+        # Register the user
+        self.test_register_user()
+
+        url = "/login"
+        data = {
+            "username": "testuser",
+            "password": "testpassword"
+        }
+        response = self.client.post(url, data, format='json')
+        json_response = json.loads(response.content)
+
+        self.assertEqual(json_response["valid"], True)
+        self.assertEqual(json_response["id"], 1)
+        self.assertIn("token", json_response)


### PR DESCRIPTION
This PR adds both the register and login functionality.  It also adds tests for each.

## Changes

- Add `/register` route to create a new user
- Add `/login` route to login as a user
- Add tests to validate the above routes

## Requests / Responses

**Request**

POST `/register` Creates a new user account

```json
{
    "username": "testuser",
    "email": "testuser@test.com",
    "password": "testpassword",
    "first_name": "test",
    "last_name": "user"
}
```

**Response**

HTTP/1.1 200 OK

```json
{
    "token": "abc123RANDOMSTRING123abc",
    "id": 1
}
```

---

POST `/login`  Login as a user

```json
{
    "username": "testuser",
    "password": "testpassword"
}
```

**Response**

HTTP/1.1 200 OK

```json
{
    "valid": true,
    "token": "abc123RANDOMSTRING123abc",
    "id": 1
}
```

---

POST `/login`  Login as a user (but provide incorrect credentials

```json
{
    "username": "testuser",
    "password": "badpassword"
}
```

**Response**

HTTP/1.1 200 OK

```json
{
    "valid": false
}
```

## Testing

Description of how to test code...

- [ ] Run seed/migration script `./seed_data.sh`
- [ ] Run test suite -> `python manage.py test tests.RegisterTests`

```
$ python manage.py test tests.RegisterTests
Creating test database for alias 'default'...
System check identified no issues (0 silenced).
...
----------------------------------------------------------------------
Ran 3 tests in 0.439s

OK
Destroying test database for alias 'default'...
```


## Related Issues

https://github.com/nswalters/AppTrakz-Client/projects/1#card-55563401
https://github.com/nswalters/AppTrakz-Client/projects/1#card-55563416