### PR TITLE
Nw enh/8/list companies

### DIFF
--- a/apptrakz/urls.py
+++ b/apptrakz/urls.py
@@ -10,6 +10,7 @@ from apptrakzapi.views import *
 
 router = routers.DefaultRouter(trailing_slash=False)
 router.register(r'user', UserView, 'user')
+router.register(r'companies', CompanyView, 'company')
 
 urlpatterns = [
     url(r'^', include(router.urls)),

--- a/apptrakzapi/models/company.py
+++ b/apptrakzapi/models/company.py
@@ -1,11 +1,11 @@
 from django.db import models
 from django.contrib.auth.models import User
-from safedelete.models import SafeDeleteModel, SOFT_DELETE
+from safedelete.models import SafeDeleteModel, SOFT_DELETE_CASCADE
 
 
 class Company(SafeDeleteModel):
 
-    _safedelete_policy = SOFT_DELETE
+    _safedelete_policy = SOFT_DELETE_CASCADE
 
     user = models.ForeignKey(User, on_delete=models.DO_NOTHING)
     name = models.CharField(max_length=200)

--- a/apptrakzapi/views/__init__.py
+++ b/apptrakzapi/views/__init__.py
@@ -1,2 +1,3 @@
 from .register import register_user, login_user
 from .user import UserView
+from .company import CompanyView

--- a/apptrakzapi/views/company.py
+++ b/apptrakzapi/views/company.py
@@ -1,0 +1,32 @@
+from django.contrib.auth.models import User
+from rest_framework import serializers, status
+from rest_framework.response import Response
+from rest_framework.viewsets import ViewSet
+
+from apptrakzapi.models import Company
+
+
+class CompanyView(ViewSet):
+
+    def list(self, request):
+        """
+        Handle GET requests to list all companies for the current user
+        """
+        current_user = User.objects.get(pk=request.auth.user.id)
+
+        # Return companies sorted alphabetically
+        companies = Company.objects.filter(user=current_user).order_by('name')
+
+        serializer = CompanySerializer(
+            companies, many=True, context={'request': request})
+
+        return Response(serializer.data)
+
+
+class CompanySerializer(serializers.HyperlinkedModelSerializer):
+
+    class Meta:
+        model = Company
+        fields = ('id', 'name', 'address1', 'address2',
+                  'city', 'state', 'zipcode', 'website')
+        depth = 1

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,2 +1,3 @@
+from .company import CompanyTests
 from .register import RegisterTests
 from .user import UserTests

--- a/tests/company.py
+++ b/tests/company.py
@@ -1,0 +1,89 @@
+from django.contrib.auth.models import User
+import json
+from rest_framework import status
+from rest_framework.authtoken.models import Token
+from rest_framework.test import APITestCase
+
+from apptrakzapi.models import Company
+
+
+class CompanyTests(APITestCase):
+    def setUp(self) -> None:
+        """
+        Configure initial requirements for Company Tests
+        """
+
+        # create our user
+        url = "/register"
+        data = {
+            "username": "testuser",
+            "email": "testuser@test.com",
+            "password": "testpassword",
+            "first_name": "test",
+            "last_name": "user"
+        }
+        response = self.client.post(url, data, format='json')
+        json_response = json.loads(response.content)
+        self.token = json_response["token"]
+        self.userID = json_response["id"]
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+
+        our_user = User.objects.get(pk=self.userID)
+
+        # create a couple of companies for that user
+        company1 = Company.objects.create(
+            user=our_user,
+            name="ZName1",
+            address1="Address1_1",
+            address2="Address2_1",
+            city="City1",
+            state="State1",
+            zipcode="11111",
+            website="Website1"
+        )
+        company1.save()
+
+        company2 = Company.objects.create(
+            user=our_user,
+            name="Name2",
+            address1="Address1_2",
+            address2="Address2_2",
+            city="City2",
+            state="State2",
+            zipcode="22222",
+            website="Website2"
+        )
+        company2.save()
+
+        # This company is 'deleted' and therefore shouldn't show up
+        # when we query for a set of companies
+        deleted_company = Company.objects.create(
+            user=our_user,
+            name="DeletedCompany",
+            address1="Address1_3",
+            address2="Address2_3",
+            city="City3",
+            state="State3",
+            zipcode="33333",
+            website="Website3"
+        )
+        deleted_company.save()
+        deleted_company.delete()
+
+    def test_get_list_user_companies(self):
+        """
+        Verify we can get all of a user's active companies in alphabetical order
+        """
+
+        url = "/companies"
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token)
+        response = self.client.get(url, None, format='json')
+        json_response = json.loads(response.content)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(json_response), 2)
+        self.assertEqual(json_response[0]["id"], 2)
+        self.assertEqual(json_response[0]['name'], "Name2")
+        self.assertEqual(json_response[1]['id'], 1)
+        self.assertEqual(json_response[1]['name'], "ZName1")


### PR DESCRIPTION
Adds support for listing all companies a user has added.

## Changes

- Creates `/companies` endpoint to list all companies
- Sets `Company` model to use `SOFT_DELETE_CASCADE` safedelete policy

## Requests / Responses

**Request - List all active companies in alphabetical order**

GET `/companies`

**Response**

HTTP/1.1 200 OK

```json
[
    {
        "id": 4,
        "name": "CAP Index, Inc.",
        "address1": "150 John Robert Thomas Drive",
        "address2": null,
        "city": "Exton",
        "state": "PA",
        "zipcode": 19341,
        "website": "https://capindex.com/"
    },
    {
        "id": 2,
        "name": "Second Company, International",
        "address1": "222 Second Street",
        "address2": null,
        "city": "Second City",
        "state": "TN",
        "zipcode": 37178,
        "website": "www.secondcompanyint.example"
    },
    {
        "id": 1,
        "name": "The First Company",
        "address1": "123 First Street",
        "address2": "Suite 111",
        "city": "First City",
        "state": "TN",
        "zipcode": 37179,
        "website": "www.idontexisasfirstcompany.example"
    }
]
```

## Testing

Description of how to test code...

- [ ] Run migrations and seed database script
- [ ] Run test suite -> `python manage.py test tests.CompanyTests`

```
$ python manage.py test tests.CompanyTests
Creating test database for alias 'default'...
System check identified no issues (0 silenced).
.
----------------------------------------------------------------------
Ran 1 test in 0.095s

OK
Destroying test database for alias 'default'...
```


## Related Issues

- Creates backend for https://github.com/nswalters/AppTrakz-Client/issues/8