### PR TITLE
Nw enh/13/create company

### DIFF
--- a/tests/company.py
+++ b/tests/company.py
@@ -87,3 +87,27 @@ class CompanyTests(APITestCase):
         self.assertEqual(json_response[0]['name'], "Name2")
         self.assertEqual(json_response[1]['id'], 1)
         self.assertEqual(json_response[1]['name'], "ZName1")
+
+    def test_create_company(self):
+        """
+        Verify we can create a company via the API
+        """
+
+        url = "/companies"
+        data = {
+            "name": "TestCompany",
+            "address1": "1234 Test St",
+            "address2": "suite 999",
+            "city": "Testing",
+            "state": "TG",
+            "zipcode": 12345,
+            "website": "https://www.test.com"
+        }
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token)
+        response = self.client.post(url, data, format='json')
+        json_response = json.loads(response.content)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(json_response["id"], 4)
+        self.assertEqual(json_response["name"], "TestCompany")
+        self.assertEqual(json_response["zipcode"], 12345)


### PR DESCRIPTION
PR includes the `create` function in the `CompanyView` to support creating a new company.  It uses the `clean_fields()` call to validate the provided fields, specifically that the `website` value contains a valid URL per the URLfield (starts with any of the following schemes: `http://`, `https://`, `ftp://` or `ftps://`).

## Changes

- Add support for POST requests to the `/companies` endpoint.
- Add test to validate functionality of the POST request

## Requests / Responses

**Request - Create a company**

POST `/companies`

```json
{
    "name": "TestCompany",
    "address1": "1234 Test St",
    "address2": "suite 999",
    "city": "Testing",
    "state": "TG",
    "zipcode": 12345,
    "website": "https://www.test.com"
}
```

**Response**

HTTP/1.1 200 OK

```json
{
    "id": 11,
    "url": "/companies/11",
    "name": "TestCompany",
    "address1": "1234 Test St",
    "address2": "suite 999",
    "city": "Testing",
    "state": "TG",
    "zipcode": 12345,
    "website": "https://www.test.com"
}
```

## Testing

Description of how to test code...

- [ ] Run migrations and seed database script
- [ ] Run test suite  -> `python manage.py test tests.CompanyTests.test_create_company`

```
$ python manage.py test tests.CompanyTests.test_create_company
Creating test database for alias 'default'...
System check identified no issues (0 silenced).
.
----------------------------------------------------------------------
Ran 1 test in 0.122s

OK
Destroying test database for alias 'default'...
```

## Related Issues

- Fixes https://github.com/nswalters/AppTrakz-Client/issues/13