### PR TITLE
Added '/jobs' POST endpoint and test to validate

### DIFF
--- a/apptrakzapi/models/job.py
+++ b/apptrakzapi/models/job.py
@@ -15,5 +15,5 @@ class Job(SafeDeleteModel):
     type = models.CharField(max_length=50)
     qualifications = models.CharField(max_length=500)
     post_link = models.URLField()
-    salary = models.CharField(max_length=20, null=True)
+    salary = models.CharField(max_length=20, null=True, blank=True)
     description = models.TextField()

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,3 +1,4 @@
 from .company import CompanyTests
+from .job import JobTests
 from .register import RegisterTests
 from .user import UserTests

--- a/tests/job.py
+++ b/tests/job.py
@@ -1,0 +1,69 @@
+# from django.contrib.auth.models import User
+import json
+from rest_framework import status
+# from rest_framework.authtoken.models import Token
+from rest_framework.test import APITestCase
+
+from apptrakzapi.models import Job
+
+
+class JobTests(APITestCase):
+    def setUp(self) -> None:
+        """
+        Configure initial requirements for Company Tests
+        """
+        # create our user
+        url = "/register"
+        data = {
+            "username": "testuser",
+            "email": "testuser@test.com",
+            "password": "testpassword",
+            "first_name": "test",
+            "last_name": "user"
+        }
+        response = self.client.post(url, data, format='json')
+        json_response = json.loads(response.content)
+        self.token = json_response["token"]
+        self.userID = json_response["id"]
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+
+        # create a company to add the job to
+        url = "/companies"
+        data = {
+            "name": "TestCompany",
+            "address1": "1234 Test St",
+            "address2": "suite 999",
+            "city": "Testing",
+            "state": "TG",
+            "zipcode": 12345,
+            "website": "https://www.test.com"
+        }
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token)
+        response = self.client.post(url, data, format='json')
+        json_response = json.loads(response.content)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    def test_create_job(self):
+        """
+        Verify we can create a job via the API
+        """
+
+        url = "/jobs"
+        data = {
+            "company": 1,
+            "role_title": "TestRole",
+            "type": "Test",
+            "qualifications": "TestQuals",
+            "post_link": "https://www.testpostlink.com",
+            "salary": None,
+            "description": "Just a test to create a job."
+        }
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token)
+        response = self.client.post(url, data, format='json')
+        json_response = json.loads(response.content)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(json_response["id"], 1)
+        self.assertEqual(json_response["role_title"], "TestRole")


### PR DESCRIPTION
This PR allows for the creation of a new job via the `/jobs` endpoint.  It also adds a test to validate such.

## Changes

- Add support for POST requests to create jobs using the `/jobs` endpoint
- Add test to validate creating a job via the `/jobs` endpoint
- Allowed potential blank values for the salary field to be used on the job model.

## Requests / Responses

**Request - Create a new job**

POST `/jobs`

```json
{
    "company": 1,
    "role_title": "TestRole",
    "type": "Test",
    "qualifications": "TestQuals",
    "post_link": "https://www.testpostlink.com",
    "salary": null,
    "description": "Just a test to create a job."
}
```

**Response**

HTTP/1.1 200 OK

```json
{
    "id": 15,
    "url": "/jobs/15",
    "company": "/companies/1",
    "role_title": "TestRole",
    "type": "Test",
    "qualifications": "TestQuals",
    "post_link": "https://www.testpostlink.com",
    "salary": null,
    "description": "Just a test to create a job."
}
```

## Testing

Description of how to test code...

- [ ] Run migrations and seed database script
- [ ] Run test suite  -> `python manage.py test tests.JobTests.test_create_job`

```
$ python manage.py test tests.JobTests.test_create_job
Creating test database for alias 'default'...
System check identified no issues (0 silenced).
.
----------------------------------------------------------------------
Ran 1 test in 0.125s

OK
Destroying test database for alias 'default'...
```

## Related Issues

- Supports https://github.com/nswalters/AppTrakz-Client/issues/14