### PR TITLE
Nw enh/21/update company

### DIFF
--- a/apptrakzapi/views/company.py
+++ b/apptrakzapi/views/company.py
@@ -11,6 +11,33 @@ from apptrakzapi.models import Company
 class CompanyView(ViewSet):
     """ Company ViewSet """
 
+    def update(self, request, pk=None):
+        """
+        Handle PUT requests for a company
+        """
+        company = Company.objects.get(pk=pk)
+        company.name = request.data["name"]
+        company.address1 = request.data["address1"]
+
+        if "address2" in request.data:
+            company.address2 = request.data["address2"]
+
+        company.city = request.data["city"]
+        company.state = request.data["state"]
+        company.zipcode = request.data["zipcode"]
+        company.website = request.data["website"]
+
+        # Validate company data then serialize
+        try:
+            company.clean_fields()
+            company.save()
+            serializer = CompanySerializer(company, context={'request': None})
+
+            return Response(serializer.data)
+
+        except ValidationError as ex:
+            return Response(ex.args[0], status=status.HTTP_400_BAD_REQUEST)
+
     def create(self, request):
         """ Handle POST operations
 

--- a/tests/application.py
+++ b/tests/application.py
@@ -73,7 +73,6 @@ class ApplicationTests(APITestCase):
         """
         url = "/applications"
         data = {
-            "user": 1,
             "job": 1
         }
         self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token)

--- a/tests/company.py
+++ b/tests/company.py
@@ -111,3 +111,29 @@ class CompanyTests(APITestCase):
         self.assertEqual(json_response["id"], 4)
         self.assertEqual(json_response["name"], "TestCompany")
         self.assertEqual(json_response["zipcode"], 12345)
+
+    def test_update_company(self):
+        """
+        Verify we can update a company via the API
+        """
+
+        self.test_create_company()
+
+        url = "/companies/4"
+        data = {
+            "name": "UpdatedCompany",
+            "address1": "1234 Test St",
+            "address2": "suite 999",
+            "city": "Testing",
+            "state": "TG",
+            "zipcode": 12345,
+            "website": "https://www.test.com"
+        }
+
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token)
+        response = self.client.put(url, data, format='json')
+        json_response = json.loads(response.content)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(json_response["id"], 4)
+        self.assertEqual(json_response["name"], "UpdatedCompany")


### PR DESCRIPTION
Adds support for PUT requests to `/companies/<id>` endpoint to update the respective company with the given id.

## Changes

- Added `update` function for updating a company
- Hotfix for an application-related test

## Requests / Responses

**Request - Updates a company record**

PUT `/companies/1`

```json
{
    "name": "CAP Index, Inc.",
    "address1": "150 John Robert Thomas Drive",
    "address2": null,
    "city": "Exton",
    "state": "PA",
    "zipcode": 19341,
    "website": "https://capindex.com/"
}
```

**Response**

HTTP/1.1 200 OK

```json
{
    "id": 4,
    "url": "/companies/4",
    "name": "CAP Index, Inc.",
    "address1": "150 John Robert Thomas Drive",
    "address2": null,
    "city": "Exton",
    "state": "PA",
    "zipcode": 19341,
    "website": "https://capindex.com/"
}
```

## Testing

Description of how to test code...

- [ ] Run migrations and seed database script `./seed_data.sh`
- [ ] Run test suite  -> `python manage.py test tests.CompanyTests.test_update_company`

```
$ python manage.py test tests.CompanyTests.test_update_company
Creating test database for alias 'default'...
System check identified no issues (0 silenced).
.
----------------------------------------------------------------------
Ran 1 test in 0.126s

OK
Destroying test database for alias 'default'...
```

## Related Issues

- Supports https://github.com/nswalters/AppTrakz-Client/issues/21