### PR TITLE
Added StatusView to list all statuses

### DIFF
--- a/apptrakz/urls.py
+++ b/apptrakz/urls.py
@@ -13,6 +13,7 @@ router.register(r'user', UserView, 'user')
 router.register(r'companies', CompanyView, 'company')
 router.register(r'jobs', JobView, 'job')
 router.register(r'applications', ApplicationView, 'application')
+router.register(r'statuses', StatusView, 'status')
 
 urlpatterns = [
     url(r'^', include(router.urls)),

--- a/apptrakzapi/fixtures/profiles.json
+++ b/apptrakzapi/fixtures/profiles.json
@@ -5,7 +5,7 @@
         "fields": {
             "user": 1,
             "bio": "bio1",
-            "profile_image": null
+            "profile_image": "profile_images/1-58b183bd326b3807a5ef9b73e8cb8a09.jpeg"
         }
     },
     {

--- a/apptrakzapi/views/__init__.py
+++ b/apptrakzapi/views/__init__.py
@@ -2,5 +2,5 @@ from .application import ApplicationView
 from .company import CompanyView
 from .job import JobView
 from .register import register_user, login_user
-# from .status import StatusView
+from .status import StatusView
 from .user import UserView

--- a/apptrakzapi/views/job.py
+++ b/apptrakzapi/views/job.py
@@ -137,7 +137,7 @@ class JobCompanySerializer(serializers.HyperlinkedModelSerializer):
 
     class Meta:
         model = Company
-        fields = ('url', 'name')
+        fields = ('id', 'url', 'name')
 
 
 class StatusSerializer(serializers.HyperlinkedModelSerializer):

--- a/apptrakzapi/views/status.py
+++ b/apptrakzapi/views/status.py
@@ -1,0 +1,25 @@
+from rest_framework import serializers, status
+from rest_framework.response import Response
+from rest_framework.viewsets import ViewSet
+
+from apptrakzapi.models import Status
+
+
+class StatusView(ViewSet):
+    """
+    Handle GET requests to list all statuses
+    """
+
+    def list(self, request):
+        statuses = Status.objects.all()
+
+        serializer = StatusSerializer(
+            statuses, many=True, context={'request': None})
+
+        return Response(serializer.data)
+
+
+class StatusSerializer(serializers.HyperlinkedModelSerializer):
+    class Meta:
+        model = Status
+        fields = ('id', 'name')


### PR DESCRIPTION
This PR adds a list view to retrieve all possible statuses.

## Changes

- Added `StatusView` with endpoint `/statuses` to list all possible statuses.
- Modified a fixture to add a default profile image.

## Requests / Responses

**Request - Lists all configured statuses**

GET `/statuses`

**Response**

HTTP/1.1 200 OK

```json
[
    {
        "id": 1,
        "name": "Applied"
    },
    {
        "id": 2,
        "name": "Phone Interview - Non Technical"
    },
    {
        "id": 3,
        "name": "Phone Interview - Technical"
    },
    {
        "id": 4,
        "name": "In-Person Interview - Non Technical"
    },
    {
        "id": 5,
        "name": "In-Person Interview - Technical"
    },
    {
        "id": 6,
        "name": "Did Not Move On"
    },
    {
        "id": 7,
        "name": "Declined To Continue"
    },
    {
        "id": 8,
        "name": "Job Offer Received"
    },
    {
        "id": 9,
        "name": "Job Offer Accepted"
    },
    {
        "id": 10,
        "name": "Job Offer Declined"
    }
]
```