### PR TITLE
Updates a job contact record -- only the contact's info

### DIFF
--- a/apptrakzapi/views/job_contact.py
+++ b/apptrakzapi/views/job_contact.py
@@ -10,6 +10,33 @@ from apptrakzapi.models import Company, Contact, Job, JobContact
 class JobContactView(ViewSet):
     """ Job Contact ViewSet """
 
+    def update(self, request, pk=None):
+        """
+        Handle PUT requests for a job contact
+        """
+        current_user = User.objects.get(pk=request.auth.user.id)
+
+        try:
+            job_contact = JobContact.objects.get(pk=pk, job__user=current_user)
+        except JobContact.DoesNotExist as ex:
+            return Response({"reason": ex.args[0]}, status=status.HTTP_404_NOT_FOUND)
+
+        contact = Contact.objects.get(id=job_contact.contact_id)
+
+        contact.first_name = request.data['first_name']
+        contact.last_name = request.data['last_name']
+        contact.phone = request.data['phone']
+        contact.email = request.data['email']
+        contact.save()
+
+        job_contact.contact = contact
+        job_contact.save()
+
+        serializer = JobContactSerializer(
+            job_contact, context={'request': None})
+
+        return Response(serializer.data)
+
     def retrieve(self, request, pk=None):
         """
         Handle GET requests for a specific job contact record


### PR DESCRIPTION
Updates the contact info of a job contact.

## Changes

- Supports PUT requests to the `/job_contacts/<id>` endpoint
- Updates only the contact info, not the job info (delete and re-create the contact if that's required)

## Requests / Responses

**Request - Update contact's info**

PUT `/job_contacts/<id>`

```json
{
    "first_name": "Ilona",
    "last_name": "Niemela",
    "phone": "048-020-19-56",
    "email": "ilona.niemela@example.com"
}
```

**Response**

HTTP/1.1 200 OK

```json
{
    "id": 1,
    "job": {
        "id": 2,
        "url": "/jobs/2",
        "role_title": "Front-End Ninja",
        "company": {
            "id": 2,
            "url": "/companies/2",
            "name": "Second Company, International"
        }
    },
    "contact": {
        "id": 1,
        "first_name": "Ilona",
        "last_name": "Niemela",
        "phone": "048-020-19-56",
        "email": "ilona.niemela@example.com"
    }
}
```

## Testing

Description of how to test code...

- [ ] Run migrations and seed database script
- [ ] Make PUT request to `/job_contacts/<id>` endpoint


## Related Issues

- Supports https://github.com/nswalters/AppTrakz-Client/issues/24