### PR TITLE
Nw enh/89/sankey

### DIFF
--- a/apptrakz/urls.py
+++ b/apptrakz/urls.py
@@ -20,5 +20,6 @@ urlpatterns = [
     url(r'^', include(router.urls)),
     url(r'^register$', register_user),
     url(r'^login$', login_user),
+    url(r'^sankey$', sankey),
     path('admin/', admin.site.urls),
 ] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)

--- a/apptrakzapi/fixtures/application_statuses.json
+++ b/apptrakzapi/fixtures/application_statuses.json
@@ -118,5 +118,41 @@
             "reason": null,
             "is_current": false
         }
+    },
+    {
+        "model": "apptrakzapi.applicationstatus",
+        "pk": 11,
+        "fields": {
+            "application_id": 5,
+            "status_id": 1,
+            "updated_at": "2018-09-01T14:52:51.060Z",
+            "created_at": "2018-09-01T14:52:51.060Z",
+            "reason": "New Application",
+            "is_current": false
+        }
+    },
+    {
+        "model": "apptrakzapi.applicationstatus",
+        "pk": 12,
+        "fields": {
+            "application_id": 5,
+            "status_id": 3,
+            "updated_at": "2018-09-07T14:52:51.060Z",
+            "created_at": "2018-09-07T14:52:51.060Z",
+            "reason": null,
+            "is_current": false
+        }
+    },
+    {
+        "model": "apptrakzapi.applicationstatus",
+        "pk": 13,
+        "fields": {
+            "application_id": 5,
+            "status_id": 5,
+            "updated_at": "2018-09-20T14:52:51.060Z",
+            "created_at": "2018-09-20T14:52:51.060Z",
+            "reason": null,
+            "is_current": false
+        }
     }
 ]

--- a/apptrakzapi/views/__init__.py
+++ b/apptrakzapi/views/__init__.py
@@ -1,7 +1,9 @@
 from .application import ApplicationView
 from .company import CompanyView
+from .connection import Connection
 from .job import JobView
 from .job_contact import JobContactView
 from .register import register_user, login_user
+from .sankey import sankey
 from .status import StatusView
 from .user import UserView

--- a/apptrakzapi/views/connection.py
+++ b/apptrakzapi/views/connection.py
@@ -1,0 +1,5 @@
+from django.conf import settings
+
+
+class Connection:
+    db_path = settings.DATABASES['default']['NAME']

--- a/apptrakzapi/views/sankey.py
+++ b/apptrakzapi/views/sankey.py
@@ -1,0 +1,171 @@
+""" Generate sankey diagram data """
+import json
+import sqlite3
+from collections import Counter
+from django.contrib.auth.models import User
+from django.conf import settings
+from django.http import HttpResponse
+
+from apptrakzapi.views import Connection
+
+
+def sankey(request):
+    auth_token = request.headers["Authorization"].split(' ')[1]
+    print(auth_token)
+
+    # current_user = 1
+
+    if request.method == 'GET':
+        with sqlite3.connect(Connection.db_path) as conn:
+            conn.row_factory = sqlite3.Row
+            db_cursor = conn.cursor()
+
+            # Get the applications statuses to use in Sankey diagram
+            db_cursor.execute("""
+                SELECT
+                    application_id,
+                    (SELECT user_id FROM authtoken_token WHERE key = ?) as user_id,
+                    CASE
+                        WHEN
+                            s.id = 1 then 'applied'
+                        WHEN
+                            s.id between 2 and 5 then 'interviewed'
+                        WHEN
+                            s.id = 6 then 'rejected'
+                        WHEN
+                            s.id = 7 then 'withdrew'
+                        WHEN
+                            s.id = 8 then 'offer'
+                        WHEN
+                            s.id = 9 then 'accepted'
+                        WHEN
+                            s.id = 10 then 'declined'
+                    END AS node
+                FROM
+                    apptrakzapi_status as s
+                JOIN
+                    apptrakzapi_applicationstatus as app_stat
+                        ON
+                            app_stat.status_id = s.id
+                JOIN
+                    apptrakzapi_application as app
+                        ON
+                            app.id = app_stat.application_id
+                WHERE
+                    app.user_id = user_id
+                GROUP BY
+                    application_id, node
+                ORDER BY
+                    application_id, created_at, node
+            """, (auth_token, ))
+
+            records = []
+            dataset = db_cursor.fetchall()
+
+            for row in dataset:
+                record = {"app": row['application_id'], "node": row["node"]}
+                records.append(record)
+
+    results = make_sankey_data(records)
+
+    return HttpResponse(json.dumps(results), content_type="application/json")
+
+
+def create_nodes_array(data):
+    """
+    Receives:
+        - Array of objects which indicate unique application statuses
+
+        - Example:
+            data = [{"app":1,"node":"applied"},{"app":2,"node":"applied"},{"app":2,"node":"interviewed"}]
+
+    Returns:
+        - Array of unique nodes objects with assigned node index
+
+        - Example:
+            nodes = [{'node': 0, 'name': 'applied'}, {'node': 1, 'name': 'interviewed'}, {'node': 2, 'name': 'rejected'}, {'node': 99, 'name': 'pending'}]
+    """
+
+    nodes = []
+    node_index = 0
+
+    for val in data:
+        node = val["node"]
+
+        if not list(filter(lambda x: x["name"] == node, nodes)):
+            nodes.append({"node": node_index, "name": node})
+            node_index += 1
+
+    # add default 'pending' node
+    nodes.append({"node": 99, "name": "pending"})
+
+    return nodes
+
+
+def create_links_array(data, nodes):
+    """
+    Receives:  
+        - [data] Array of objects which indicate unique application statuses
+        - [nodes] Array of unique nodes objects with assigned node index
+
+        - Example:
+            data = [{"app":1,"node":"applied"},{"app":2,"node":"applied"},{"app":2,"node":"interviewed"}]
+
+    Returns:
+        - Array of unique link combinations and their respective counts
+    """
+
+    links_array = []
+
+    for idx, val in enumerate(data):
+        current_app = val['app']
+
+        source_node = find_node_by_name(nodes, val['node'])['node']
+        target_node = 99  # default to pending
+
+        # Terminating values which will never have a target assigned
+        if val["node"] in ("rejected", "withdrew", "accepted", "declined"):
+            continue
+
+        # If we've reached the end, and it wasn't a terminating value,
+        # append our default pending node then exit the loop
+        if idx == len(data) - 1:
+            links_array.append((source_node, target_node))
+            break
+
+        if data[idx + 1]['app'] == current_app:
+            target_node = find_node_by_name(
+                nodes, data[idx + 1]['node'])["node"]
+            links_array.append((source_node, target_node))
+        else:
+            links_array.append((source_node, target_node))
+
+    return links_array
+
+
+def find_node_by_name(nodes_array, name):
+    return list(filter(lambda x: x["name"] == name, nodes_array))[0]
+
+
+def find_node_by_index(nodes_array, index):
+    return list(filter(lambda x: x["node"] == index, nodes_array))[0]
+
+
+def make_sankey_data(raw_data):
+    nodes = create_nodes_array(raw_data)
+    links = create_links_array(raw_data, nodes)
+
+    link_records = []
+    final_links = []
+
+    for link in links:
+        source_index = find_node_by_index(nodes, link[0])["node"]
+        target_index = find_node_by_index(nodes, link[1])["node"]
+        link_records.append((source_index, target_index))
+
+    link_record_counts = Counter(link_records)
+
+    for key, val in link_record_counts.items():
+        final_links.append({"source": key[0], "target": key[1], "value": val})
+
+    return {"nodes": nodes, "links": final_links}


### PR DESCRIPTION
This PR creates the `/sankey` endpoint to retrieve the required data for generating a Sankey diagram using d3-sankey.

This endpoint first queries the database using `CASE` statements to generate categories of statuses that we want reflected in our diagram.  This result set is grouped by the application_id then the node, and finally ordered by the `application_id, created_at, node`.  This logic gives us a list of statuses in the order they were created for each application.  This is important later as we will rely on the ordering of these nodes to determine the order of status changes. 

Example returned data:

![image](https://user-images.githubusercontent.com/10491407/111404126-3d83cc80-869c-11eb-9721-8ca988794106.png)


After retrieving the list of status updates, we then need to start creating our Sankey data.  This data consists of two arrays.  

**Nodes Array**
The first, `nodes`, is an array of objects where each of the unique statuses from the above retrieved data is assigned unique index, along with adding any other supporting nodes required (i.e. `pending` node).  

In order to generate this array, we iterate over the list of all application statuses we received from the above query.  If we haven't already seen that node (i.e. it isn't already in our list) we transform those values into a dictionary, and then append (load) that dictionary onto our list of nodes, assigning an incrementing node id value.  The final result is a `nodes` list containing unique `node` objects, consisting of a node id and the node name.

**Links Array**

The second array is an array of objects, each of which have three required values: `source`, `target`, and `value`.  The `source` value is the originator of the action.  The `target` is the next step taken, i.e. the target of the source.  Finally the `value` field will be the overall count of how many times this exact pattern was made throughout all of the status updates.

> You can think of this like stepping stones.  You start from the first stone (the source) and then move to the second (the target).  You would then move from the second (the source) to the third (the target).  If you were to then step off, and start back at the first stone, moving to the second stone, you would then have 2 events for `first stone -> second stone` and 1 event for `second stone -> third stone`.  This is the basic gist of what we're doing here.

To generate this list, we start with the first data point.  We create a marker, `current_app`, get the `node id` from our nodes array we just created for the respective node name in the data point.  Next we have to make sure that node isn't what we deem a `terminating` node, i.e. a node which will never have a target. If this is a terminating node, then we do nothing and move on to the next record.

Next, we need to handle if we've reached the of our data but the current data point isn't a terminating node.  If that is the case, then we push one last node, a 'pending' node, into our list before breaking out of our loop.

If we have not reached the end of our data, then we need to do a 'look-ahead' to the next data record and check if that record shared the same application id as the current record.  If so, then we know that's the next target and create the required source/target mapping.  If the next data record's application id _doesn't_ match the current record's, then we know that we're still waiting on a response and therefore we push a `pending` record on to the list.

Finally, we move to the next iteration of the loop, resetting the application marker to the new record, and continue the logic until there are no more data points to ingest.  We then return the dataset.  This will complete the processing required of the data itself before being handed off to d3-sankey to create the diagram.

The final resulting dataset looks like the following:

```json
{
  "nodes": [
    {"node": 0, "name": "applied"},
    {"node": 1, "name": "interviewed"},
    {"node": 2, "name": "rejected"},
    {"node": 3, "name": "withdrew"},
    {"node": 4, "name": "offer"},
    {"node": 99, "name": "pending"}
],
  "links": [
    {"source": 0, "target": 99, "value": 1},
    {"source": 0, "target": 1, "value": 3},
    {"source": 1, "target": 99, "value": 1},
    {"source": 1, "target": 2, "value": 1},
    {"source": 0, "target": 3, "value": 1},
    {"source": 1, "target": 4, "value": 1},
    {"source": 4, "target": 99, "value": 1}
]}
```

The `links` section has one object which has a value of `3`.  This indicates that we `applied -> interviewed` a total of three times (source 0 = node 0 = applied, target 1 = node 1 = interviewed).

You might also notice that the `target 99` value shows up multiple times.  What that means is that we had the following steps (I've included the node id's in parens for clarity):

`applied (0) -> pending (99)` - i.e. we've applied for a job and haven't gotten a response (status hasn't been updated)
`interviewed (1) -> pending (99)` - i.e. we've interviewed and are pending a response
`offer (4) -> pending (99)` - i.e. we've received an offer and a response is pending.

## Changes

- Added the `/sankey` endpoint to retrieve the necessary data for the current user's sankey diagram.
- Added additional statuses in the fixtures to ensure we always had records that started with 'Applied' status, as well as some additional status updates to flesh out the dataset.


## Requests / Responses

_**See Above Explanation**_

## Testing

N/A at this time...

## Related Issues

- Supports #89