### PR TITLE
Fixed 'WHERE' clause on query via updating alias to be unique. Remove unnecessary print statement.

### DIFF
--- a/apptrakzapi/views/sankey.py
+++ b/apptrakzapi/views/sankey.py
@@ -11,9 +11,6 @@ from apptrakzapi.views import Connection
 
 def sankey(request):
     auth_token = request.headers["Authorization"].split(' ')[1]
-    print(auth_token)
-
-    # current_user = 1
 
     if request.method == 'GET':
         with sqlite3.connect(Connection.db_path) as conn:
@@ -24,7 +21,7 @@ def sankey(request):
             db_cursor.execute("""
                 SELECT
                     application_id,
-                    (SELECT user_id FROM authtoken_token WHERE key = ?) as user_id,
+                    (SELECT user_id FROM authtoken_token WHERE key = ?) as uid,
                     CASE
                         WHEN
                             s.id = 1 then 'applied'
@@ -52,7 +49,7 @@ def sankey(request):
                         ON
                             app.id = app_stat.application_id
                 WHERE
-                    app.user_id = user_id
+                    app.user_id = uid
                 GROUP BY
                     application_id, node
                 ORDER BY


### PR DESCRIPTION
The WHERE clause was using a value which wasn't referencing the proper field (the user_id from the authtoken table).  Made the alias unique on that select query and updated the WHERE clause to use the new alias and query is working as expected.