### PR TITLE
Nw/fix/sankey duplicates

### DIFF
--- a/apptrakzapi/views/sankey.py
+++ b/apptrakzapi/views/sankey.py
@@ -28,10 +28,10 @@ def sankey(request):
             # Get the applications statuses to use in Sankey diagram
 
             db_cursor.execute("""
-                SELECT DISTINCT
-                    application_id, node
+                SELECT
+                    *
                 FROM
-                (SELECT DISTINCT
+                (SELECT DISTINCT ON (application_id, node)
                     created_at,
                     application_id,
                     CASE
@@ -72,8 +72,10 @@ def sankey(request):
                     authtoken_token.key = %s
                 AND
                     app.deleted IS null
+                GROUP BY
+                    application_id, app_stat.created_at, node) q
                 ORDER BY
-                    application_id, created_at, node) as query
+                    application_id, created_at
             """, (auth_token, ))
 
             # db_cursor.execute("""

--- a/apptrakzapi/views/sankey.py
+++ b/apptrakzapi/views/sankey.py
@@ -72,7 +72,7 @@ def sankey(request):
                 --    application_id, node, created_at
                 ORDER BY
                     -- application_id, created_at, node;
-                    application_id, created_at, node;
+                    application_id, node;
             """, (auth_token, ))
 
             # db_cursor.execute("""

--- a/apptrakzapi/views/sankey.py
+++ b/apptrakzapi/views/sankey.py
@@ -28,7 +28,7 @@ def sankey(request):
             # Get the applications statuses to use in Sankey diagram
 
             db_cursor.execute("""
-                            SELECT
+                SELECT DISTINCT
                     application_id,
                     CASE
                         WHEN
@@ -68,9 +68,10 @@ def sankey(request):
                     authtoken_token.key = %s
                 AND
                     app.deleted IS null
-                GROUP BY
-                    application_id, node, created_at
+                -- GROUP BY
+                --    application_id, node, created_at
                 ORDER BY
+                    -- application_id, created_at, node;
                     application_id, created_at, node;
             """, (auth_token, ))
 

--- a/apptrakzapi/views/sankey.py
+++ b/apptrakzapi/views/sankey.py
@@ -29,6 +29,7 @@ def sankey(request):
 
             db_cursor.execute("""
                 SELECT DISTINCT
+                    created_at,
                     application_id,
                     CASE
                         WHEN
@@ -72,7 +73,7 @@ def sankey(request):
                 --    application_id, node, created_at
                 ORDER BY
                     -- application_id, created_at, node;
-                    application_id, node;
+                    application_id, created_at, node;
             """, (auth_token, ))
 
             # db_cursor.execute("""

--- a/apptrakzapi/views/sankey.py
+++ b/apptrakzapi/views/sankey.py
@@ -29,6 +29,9 @@ def sankey(request):
 
             db_cursor.execute("""
                 SELECT DISTINCT
+                    application_id, node
+                FROM
+                (SELECT DISTINCT
                     created_at,
                     application_id,
                     CASE
@@ -69,11 +72,8 @@ def sankey(request):
                     authtoken_token.key = %s
                 AND
                     app.deleted IS null
-                -- GROUP BY
-                --    application_id, node, created_at
                 ORDER BY
-                    -- application_id, created_at, node;
-                    application_id, created_at, node;
+                    application_id, created_at, node) as query
             """, (auth_token, ))
 
             # db_cursor.execute("""


### PR DESCRIPTION
Postgres was not handling the query the same as Sqlite3 did.  This caused a duplicate entry if you selected a status that shared a category with a previous status (such as moving from 'phone interview' to 'in-person interview' both of which share a 'interview' category.  The duplicate entry would then cause a circular reference in the Sankey diagram which caused an error.

Additionally, there was an issue where using a DISTINCT query at the top-level resulted in the columns being ordered differently than expected, also causing an issue when trying to reflect the proper flow.

I updated the SQL query so that it uses a subquery which selects the DISTINCT records which is wrapped by a SELECT which handles the proper ordering by the `created_at` time.